### PR TITLE
Refactor/clarify serialisation routine

### DIFF
--- a/TestDataAccess.Tests/JsonFileTests.cs
+++ b/TestDataAccess.Tests/JsonFileTests.cs
@@ -52,10 +52,13 @@ namespace TestDataAccess.Tests
             var jsonFile = new JSONFile(FullFilePath);
             var testDataKey = "Animals";
             var testDataIndex = 0;
+            var expectedValue = "Dog";
 
             var jsonReader = CreateJSONReader(jsonFile);
+            var testValue = jsonReader.GetJsonPropertyValue(testDataKey, testDataIndex);
 
-            Assert.Equals(jsonReader, "Dog");
+
+            Assert.AreEqual(testValue, expectedValue);
         }
 
         private static JSONReader CreateJSONReader(JSONFile jsonFile)

--- a/TestDataAccess.Tests/JsonFileTests.cs
+++ b/TestDataAccess.Tests/JsonFileTests.cs
@@ -6,7 +6,7 @@ using NUnit.Framework;
 namespace TestDataAccess.Tests
 {
     [TestFixture]
-    public class JsonFile
+    public class JsonFileTests
     {
         private static readonly string SolutionBinary = System.AppContext.BaseDirectory;
         private static readonly string SolutionName = "TestDataAccess.Tests";

--- a/TestDataAccess.Tests/UnitTest1.cs
+++ b/TestDataAccess.Tests/UnitTest1.cs
@@ -42,7 +42,7 @@ namespace TestDataAccess.Tests
 
             Assert.DoesNotThrow(() =>
             {
-                var jsonReader = CreateJSONReader(jsonFile, testDataKey, testDataIndex);
+                var jsonReader = CreateJSONReader(jsonFile);
             });
         }
 
@@ -53,14 +53,14 @@ namespace TestDataAccess.Tests
             var testDataKey = "Animals";
             var testDataIndex = 0;
 
-            var jsonReader = CreateJSONReader(jsonFile, testDataKey, testDataIndex);
+            var jsonReader = CreateJSONReader(jsonFile);
 
             Assert.Equals(jsonReader, "Dog");
         }
 
-        private static JSONReader CreateJSONReader(JSONFile jsonFile, string testDataKey, int testDataIndex)
+        private static JSONReader CreateJSONReader(JSONFile jsonFile)
         {
-            return new JSONReader(jsonFile, testDataKey, testDataIndex);
+            return new JSONReader(jsonFile);
         }
 
         private static JSONFile CreateJSONFile(string filePath)

--- a/TestDataAccess/JSONReader.cs
+++ b/TestDataAccess/JSONReader.cs
@@ -35,6 +35,14 @@ namespace TestDataAccess
                 .DeserializeObject<Dictionary<string, string>>(testDataAtTestDataIndex.ToString());
         }
 
+        /// <summary>
+        /// Returns a nested level JSON collection value by specifying its key, collection index level and parent key and index.
+        /// </summary>
+        /// <param name="testDataKey"></param>
+        /// <param name="testDataIndex"></param>
+        /// <param name="subKey"></param>
+        /// <param name="subIndex"></param>
+        /// <returns></returns>
         public Dictionary<string, string> GetNestedKeyAndIndexValue(string testDataKey, int testDataIndex, string subKey, int subIndex)
         {
             JObject testDataAtTestDataSubIndex =
@@ -44,6 +52,12 @@ namespace TestDataAccess
                     .DeserializeObject<Dictionary<string, string>>(testDataAtTestDataSubIndex.ToString());
         }
 
+        /// <summary>
+        /// Returns a root level JSON collection value by specifying its key.
+        /// </summary>
+        /// <param name="testDataKey"></param>
+        /// <param name="testDataIndex"></param>
+        /// <returns></returns>
         public Dictionary<string, string[]> GetArrayThruKeyAndIndexValue(string testDataKey, int testDataIndex)
         {
             JObject testDataAtTestDataIndex =

--- a/TestDataAccess/JSONReader.cs
+++ b/TestDataAccess/JSONReader.cs
@@ -25,7 +25,7 @@ namespace TestDataAccess
         public Dictionary<string, string> GetKeyAndIndexValue(string testDataKey, int testDataIndex)
         {
             var testDataAtTestDataIndex =
-                this.GetKeyAndIndexValueFromJObject(this.JsonFile, testDataKey, testDataIndex);
+                this.GetKeyAndIndexValueFromJObject(testDataKey, testDataIndex);
 
             return JsonConvert
                 .DeserializeObject<Dictionary<string, string>>(testDataAtTestDataIndex.ToString());
@@ -42,7 +42,7 @@ namespace TestDataAccess
         public Dictionary<string, string> GetNestedKeyAndIndexValue(string testDataKey, int testDataIndex, string subKey, int subIndex)
         {
             JObject testDataAtTestDataSubIndex =
-                (JObject)this.GetKeyAndIndexValueFromJObject(this.JsonFile, testDataKey, testDataIndex)
+                (JObject)this.GetKeyAndIndexValueFromJObject(testDataKey, testDataIndex)
                     .GetValue(subKey).ElementAt(subIndex);
             return JsonConvert
                     .DeserializeObject<Dictionary<string, string>>(testDataAtTestDataSubIndex.ToString());
@@ -57,7 +57,7 @@ namespace TestDataAccess
         public Dictionary<string, string[]> GetArrayThruKeyAndIndexValue(string testDataKey, int testDataIndex)
         {
             JObject testDataAtTestDataIndex =
-                (JObject)this.GetKeyAndIndexValueFromJObject(this.JsonFile, testDataKey, testDataIndex);
+                (JObject)this.GetKeyAndIndexValueFromJObject(testDataKey, testDataIndex);
 
                 return JsonConvert
                     .DeserializeObject<Dictionary<string, string[]>>(testDataAtTestDataIndex.ToString());
@@ -68,15 +68,14 @@ namespace TestDataAccess
         /// the requested test data
         /// </summary>
         /// <returns>JObject that represents the JSON file</returns>
-        private static JObject ConvertJSONFileToJObject(JSONFile jsonFile)
+        private JObject ConvertJSONFileToJObject()
         {
-            if (jsonFile == null)
+            if (this.JsonFile == null)
             {
-                throw new ArgumentException($"JSONFile, {nameof(jsonFile)} can't be null");
+                throw new ArgumentException($"JSONFile, {nameof(this.JsonFile)} can't be null");
             }
 
-            using (StreamReader file = File.
-                OpenText(jsonFile.FilePath))
+            using (StreamReader file = File.OpenText(this.JsonFile.FilePath))
             {
                 using (JsonTextReader reader = new JsonTextReader(file))
                 {
@@ -92,12 +91,23 @@ namespace TestDataAccess
         /// <param name="testDataKey">key property for the testdata</param>
         /// <param name="index">Index of the testcase(s)</param>
         /// <returns></returns>
-        private JObject GetKeyAndIndexValueFromJObject(JSONFile jsonFile,
+        private JObject GetKeyAndIndexValueFromJObject(
             string testDataKey, int index)
         {
-            return (JObject)ConvertJSONFileToJObject(jsonFile)
-                .GetValue(testDataKey)
-                .ElementAt(index);
+            var jObject = this.ConvertJSONFileToJObject();
+            var value = jObject.GetValue(testDataKey);
+            var element = value.ElementAt(index);
+
+            return (JObject)element;
+        }
+
+        public string GetJsonPropertyValue(string testDataKey, int index)
+        {
+            var jObject = this.ConvertJSONFileToJObject();
+            var value = jObject.GetValue(testDataKey);
+            var element = value.ElementAt(index);
+
+            return element.ToString();
         }
     }
 }

--- a/TestDataAccess/JSONReader.cs
+++ b/TestDataAccess/JSONReader.cs
@@ -18,7 +18,7 @@ namespace TestDataAccess
             string testDataKey, int testDataIndex)
         {
             var testDataAtTestDataIndex =
-                testData(jsonFile, testDataKey, testDataIndex);
+                this.GetKeyAndIndexValueFromJObject(jsonFile, testDataKey, testDataIndex);
 
             TestCaseValues = JsonConvert
                 .DeserializeObject<Dictionary<string, string>>(testDataAtTestDataIndex.ToString());
@@ -34,7 +34,7 @@ namespace TestDataAccess
             string testDataKey, int testDataIndex, bool testDataIsInArray)
         {
             JObject testDataAtTestDataIndex =
-                (JObject)testData(jsonFile, testDataKey, testDataIndex);
+                (JObject)this.GetKeyAndIndexValueFromJObject(jsonFile, testDataKey, testDataIndex);
 
             if (!testDataIsInArray)
             {
@@ -62,7 +62,7 @@ namespace TestDataAccess
             {
 
                 JObject testDataAtTestDataSubIndex =
-                    (JObject)testData(jsonFile, testDataKey, testDataIndex)
+                    (JObject)this.GetKeyAndIndexValueFromJObject(jsonFile, testDataKey, testDataIndex)
                         .GetValue(subKey).ElementAt(subIndex);
                 TestCaseValues =
                     JsonConvert
@@ -101,12 +101,12 @@ namespace TestDataAccess
         /// <param name="testDataKey">key property for the testdata</param>
         /// <param name="index">Index of the testcase(s)</param>
         /// <returns></returns>
-        private JObject testData(JSONFile jsonFile,
+        private JObject GetKeyAndIndexValueFromJObject(JSONFile jsonFile,
             string testDataKey, int index)
         {
             return (JObject)ConvertJSONFileToJObject(jsonFile)
-                .GetValue(testDataKey).ElementAt(index);
+                .GetValue(testDataKey)
+                .ElementAt(index);
         }
     }
-
 }

--- a/TestDataAccess/JSONReader.cs
+++ b/TestDataAccess/JSONReader.cs
@@ -10,10 +10,6 @@ namespace TestDataAccess
     public class JSONReader
     {
         private JSONFile JsonFile;
-        public static Dictionary<string, string[]> TestValues;
-        public static Dictionary<string, string[]> TestJsonArrayValues;
-        public static Dictionary<string, string> TestCaseValues;
-        public static int ListCount;
 
         public JSONReader(JSONFile jsonFile)
         {

--- a/TestDataAccess/JSONReader.cs
+++ b/TestDataAccess/JSONReader.cs
@@ -9,72 +9,53 @@ namespace TestDataAccess
 {
     public class JSONReader
     {
+        private JSONFile JsonFile;
         public static Dictionary<string, string[]> TestValues;
         public static Dictionary<string, string[]> TestJsonArrayValues;
         public static Dictionary<string, string> TestCaseValues;
         public static int ListCount;
 
-        public JSONReader(JSONFile jsonFile,
-            string testDataKey, int testDataIndex)
+        public JSONReader(JSONFile jsonFile)
+        {
+            this.JsonFile = jsonFile;
+        }
+
+        /// <summary>
+        /// Returns a root level JSON collection value by specifying its key and collection index level.
+        /// </summary>
+        /// <param name="testDataKey"></param>
+        /// <param name="testDataIndex"></param>
+        /// <returns></returns>
+        public Dictionary<string, string> GetKeyAndIndexValue(string testDataKey, int testDataIndex)
         {
             var testDataAtTestDataIndex =
-                this.GetKeyAndIndexValueFromJObject(jsonFile, testDataKey, testDataIndex);
+                this.GetKeyAndIndexValueFromJObject(this.JsonFile, testDataKey, testDataIndex);
 
-            TestCaseValues = JsonConvert
+            return JsonConvert
                 .DeserializeObject<Dictionary<string, string>>(testDataAtTestDataIndex.ToString());
         }
 
-        /// <summary>
-        /// Constructor for a JSONReader to read the testCaseValues from a JSON File
-        /// </summary>
-        /// <param name="testDataKey"></param>
-        /// <param name="testDataIndex">Index of the test case in JSON file</param>
-        /// <param name="testDataIsInArray">To check if the test data is in an array</param>
-        public JSONReader(JSONFile jsonFile,
-            string testDataKey, int testDataIndex, bool testDataIsInArray)
+        public Dictionary<string, string> GetNestedKeyAndIndexValue(string testDataKey, int testDataIndex, string subKey, int subIndex)
         {
-            JObject testDataAtTestDataIndex =
-                (JObject)this.GetKeyAndIndexValueFromJObject(jsonFile, testDataKey, testDataIndex);
-
-            if (!testDataIsInArray)
-            {
-                TestCaseValues = JsonConvert
-                    .DeserializeObject<Dictionary<string, string>>(testDataAtTestDataIndex.ToString());
-            }
-            else
-            {
-                TestJsonArrayValues = JsonConvert
-                    .DeserializeObject<Dictionary<string, string[]>>(testDataAtTestDataIndex.ToString());
-            }
+            JObject testDataAtTestDataSubIndex =
+                (JObject)this.GetKeyAndIndexValueFromJObject(this.JsonFile, testDataKey, testDataIndex)
+                    .GetValue(subKey).ElementAt(subIndex);
+            return JsonConvert
+                    .DeserializeObject<Dictionary<string, string>>(testDataAtTestDataSubIndex.ToString());
         }
 
-        /// <summary>
-        /// Read a value from JSON Data Structure with Sub Objects and Sub Indexes
-        /// </summary> 
-        /// <param name="testDataKey">To access the value of the JSON property representing
-        /// the test data</param>
-        /// <param name="testDataIndex"></param>
-        /// <param name="subKey">to get the the value of the subKey in the JSON Object</param>
-        /// <param name="subIndex">Array Index of the value to be read in the subKey</param> 
-        public JSONReader(JSONFile jsonFile, string testDataKey,
-            int testDataIndex, string subKey, int subIndex)
+        public Dictionary<string, string[]> GetArrayThruKeyAndIndexValue(string testDataKey, int testDataIndex)
         {
-            {
+            JObject testDataAtTestDataIndex =
+                (JObject)this.GetKeyAndIndexValueFromJObject(this.JsonFile, testDataKey, testDataIndex);
 
-                JObject testDataAtTestDataSubIndex =
-                    (JObject)this.GetKeyAndIndexValueFromJObject(jsonFile, testDataKey, testDataIndex)
-                        .GetValue(subKey).ElementAt(subIndex);
-                TestCaseValues =
-                    JsonConvert
-                        .DeserializeObject<Dictionary<string, string>>(testDataAtTestDataSubIndex.ToString());
-                ListCount = TestCaseValues.Count;
-
-            }
+                return JsonConvert
+                    .DeserializeObject<Dictionary<string, string[]>>(testDataAtTestDataIndex.ToString());
         }
 
         /// <summary>
         /// To convert the JSON file contents to a JObject to use to to filter the JSON Object, and find the
-        ///the requested test data
+        /// the requested test data
         /// </summary>
         /// <returns>JObject that represents the JSON file</returns>
         private static JObject ConvertJSONFileToJObject(JSONFile jsonFile)


### PR DESCRIPTION
This PR contains some changes to the JSONReader class that moves the behavioral logic outside of the class constructor, and into separate functions. By removing the constructors we have a clear separation between class instantiation and class behavior... before it was a bit murky and hard to tell what each one was doing.